### PR TITLE
mise à jour taille du clip (taille d'écran) + séquenceur invisible

### DIFF
--- a/clips/claes_louis/sketch.js
+++ b/clips/claes_louis/sketch.js
@@ -62,9 +62,9 @@ function preload(){
 }
 
 function setup(){
-	createCanvas(window.innerWidth, window.innerHeight);
+	createCanvas(1920,1080);
 	//séquenceur
-	sequencer = new Sequencer(audiopath , 40 , true);
+	sequencer = new Sequencer(audiopath , 40 , false);
 	sequencer.registerSequence({
 		name : "bulles",
 		start : 8+1/2,


### PR DESCRIPTION
Bonjour Monsieur , j'ai fait une mise à jour de la taille de l'écran (donc je l'ai mis dans les dimensions de mon propre écran ) en espérant que le problème soit maintenant résolu .
J'en ai aussi profité pour rendre les nombres rouges invisibles (c'est plus joli)
Voilà voilà
Bonne soirée 